### PR TITLE
Fix package

### DIFF
--- a/helm-qiita.el
+++ b/helm-qiita.el
@@ -278,3 +278,4 @@ Argument EVENT is a string describing the type of event."
   (helm-qiita:set-timer))
 
 (provide 'helm-qiita)
+;;; helm-qiita.el ends here

--- a/helm-qiita.el
+++ b/helm-qiita.el
@@ -177,7 +177,7 @@ Argument CANDIDATE a line string of a stock."
   "Receive a response of `helm-qiita:http-request'.
 Argument PROCESS is a http-request process.
 Argument EVENT is a string describing the type of event."
-  (let (response next-link stock)
+  (let (valid-response response next-link stock)
     (with-current-buffer (get-buffer helm-qiita:http-buffer-name)
       (setq valid-response (helm-qiita:valid-http-responsep))
       (setq next-link (helm-qiita:next-link))

--- a/helm-qiita.el
+++ b/helm-qiita.el
@@ -5,7 +5,7 @@
 ;; Author: Takashi Masuda <masutaka.net@gmail.com>
 ;; URL: https://github.com/masutaka/emacs-helm-qiita
 ;; Version: 0.0.1
-;; Package-Requires: ((helm "20160401.1145"))
+;; Package-Requires: ((helm "20160401.1145") (cl-lib "0.5"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -27,6 +27,7 @@
 
 (require 'helm)
 (require 'json)
+(require 'cl-lib)
 
 (defgroup helm-qiita nil
   "Qiita with helm interface"
@@ -237,7 +238,7 @@ Argument EVENT is a string describing the type of event."
 (defun helm-qiita:stock-tags (stock)
   (let ((tags (cdr (assoc 'tags stock))) result)
     (dotimes (i (length tags))
-      (add-to-list 'result (cdr (assoc 'name (aref tags i)))))
+      (cl-pushnew (cdr (assoc 'name (aref tags i))) result :test #'equal))
     (reverse result)))
 
 (defun helm-qiita:http-debug-start ()


### PR DESCRIPTION
- Add package footer
- Fix using free variable
- Use `cl-pushnew` instead of `add-to-list` because Emacs does not permit to apply `add-to-list` for lexical local variable

```
helm-qiita.el:239:25:Error: ‘add-to-list’ can’t use lexical var ‘result’; use
    ‘push’ or ‘cl-pushnew’
```
