### PR TITLE
Suppress byte-compile warning

### DIFF
--- a/helm-qiita.el
+++ b/helm-qiita.el
@@ -175,7 +175,7 @@ Use `helm-qiita-url' if URL is nil."
 			curl-args))
       (set-process-sentinel proc 'helm-qiita-http-request-sentinel))))
 
-(defun helm-qiita-http-request-sentinel (process event)
+(defun helm-qiita-http-request-sentinel (process _event)
   "Receive a response of `helm-qiita-http-request'.
 PROCESS is a http-request process.
 EVENT is a string describing the type of event."


### PR DESCRIPTION
This fixes a following warning.

```
helm-qiita.el:178:1:Warning: Unused lexical argument `event
```
